### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/mediumish.js
+++ b/assets/js/mediumish.js
@@ -117,7 +117,8 @@ jQuery(document).ready(function($){
 var loadDeferredStyles = function () {
 	var addStylesNode = document.getElementById("deferred-styles");
 	var replacement = document.createElement("div");
-	replacement.innerHTML = addStylesNode.textContent;
+	var textNode = document.createTextNode(addStylesNode.textContent);
+	replacement.appendChild(textNode);
 	document.body.appendChild(replacement);
 	addStylesNode.parentElement.removeChild(addStylesNode);
 };


### PR DESCRIPTION
Fixes [https://github.com/sela/amthuc-viet/security/code-scanning/1](https://github.com/sela/amthuc-viet/security/code-scanning/1)

To fix the problem, we need to ensure that the text content is not interpreted as HTML. Instead of setting `replacement.innerHTML`, we should create a text node and append it to the `replacement` element. This way, any text content will be treated as plain text, not HTML.

- Replace the line where `replacement.innerHTML` is set with code that creates a text node from `addStylesNode.textContent` and appends it to `replacement`.
- This change ensures that any text content is safely added to the DOM without the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
